### PR TITLE
https://github.com/webjars/jquery-validation/issues/7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>jquery</artifactId>
-            <version>[1.9.1,)</version>
+            <version>1.9.1</version>
         </dependency>
     </dependencies>
     <properties>


### PR DESCRIPTION
There was an open upper bound on the jquery dependency - [1.9.1,)
This open upper bound causes jquery-validation to bring in jquery 3.0.0alpha1.
Specifying the bound as 1.9.1 allows normal eviction of jquery to occur -
our build will evict all jquery dependencies in favour of the greatest in our transitive dependencies.
This is preferable to always evicting in favour of the greatest jquery version available in the resolvers.

@jamesward Should I adjust the webjar version from SNAPSHOT, or just leave it? I am wondering if the webjar version might get bumped 1.14.1-SNAPSHOT and a release tagged by a release process?